### PR TITLE
Always set head data per route

### DIFF
--- a/app/routes/chairs-message.js
+++ b/app/routes/chairs-message.js
@@ -21,6 +21,7 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   afterModel() {
     const title = `${get(this, 'intl').t('chairsMessage.title')} | ${get(this, 'intl').t('title')}`;
     set(this, 'headData.title', title);
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}chairs-message/`);
     const backgroundImage = get(this, 'backgroundImage').getSlideBackgroundImage('chairs-message');
     if (backgroundImage && backgroundImage.fullSizeUrl) {

--- a/app/routes/financials/auditors-report.js
+++ b/app/routes/financials/auditors-report.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   assetLoader: service(),
+  backgroundImage: service(),
   headData: service(),
   intl: service(),
 
@@ -20,6 +21,8 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   afterModel() {
     const title = `${get(this, 'intl').t('financials.title')} | ${get(this, 'intl').t('title')}`;
     set(this, 'headData.title', title);
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}financials/auditors-report/`);
+    set(this, 'headData.image', get(this, 'backgroundImage.defaultBackground.fullSizeUrl'));
   },
 });

--- a/app/routes/financials/balance-sheet.js
+++ b/app/routes/financials/balance-sheet.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   assetLoader: service(),
+  backgroundImage: service(),
   headData: service(),
   intl: service(),
 
@@ -20,6 +21,8 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   afterModel() {
     const title = `${get(this, 'intl').t('financials.title')} | ${get(this, 'intl').t('title')}`;
     set(this, 'headData.title', title);
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}financials/balance-sheet/`);
+    set(this, 'headData.image', get(this, 'backgroundImage.defaultBackground.fullSizeUrl'));
   },
 });

--- a/app/routes/financials/notes.js
+++ b/app/routes/financials/notes.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   assetLoader: service(),
+  backgroundImage: service(),
   headData: service(),
   intl: service(),
 
@@ -20,6 +21,8 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   afterModel() {
     const title = `${get(this, 'intl').t('financials.title')} | ${get(this, 'intl').t('title')}`;
     set(this, 'headData.title', title);
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}financials/notes/`);
+    set(this, 'headData.image', get(this, 'backgroundImage.defaultBackground.fullSizeUrl'));
   },
 });

--- a/app/routes/financials/revenue-and-expenses.js
+++ b/app/routes/financials/revenue-and-expenses.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   assetLoader: service(),
+  backgroundImage: service(),
   headData: service(),
   intl: service(),
 
@@ -20,6 +21,8 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   afterModel() {
     const title = `${get(this, 'intl').t('financials.title')} | ${get(this, 'intl').t('title')}`;
     set(this, 'headData.title', title);
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}financials/revenue-and-expenses/`);
+    set(this, 'headData.image', get(this, 'backgroundImage.defaultBackground.fullSizeUrl'));
   },
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,16 +1,27 @@
+import ENV from 'annual-report-2019/config/environment';
 import GoogleAnalyticsMixin from 'annual-report-2019/mixins/google-analytics';
 import ResetScrollMixin from 'annual-report-2019/mixins/reset-scroll';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   assetLoader: service(),
+  backgroundImage: service(),
+  headData: service(),
+  intl: service(),
 
   beforeModel() {
     if (!get(this, 'assetLoader.assetsLoaded')) {
       return get(this, 'assetLoader').waitForAssets();
     }
     return true;
+  },
+
+  afterModel() {
+    set(this, 'headData.title', get(this, 'intl').t('title'));
+    set(this, 'headData.description', get(this, 'intl').t('description'));
+    set(this, 'headData.url', `${ENV.host}${ENV.rootURL}`);
+    set(this, 'headData.image', get(this, 'backgroundImage.defaultBackground.fullSizeUrl'));
   },
 });

--- a/app/routes/outputs-and-activities.js
+++ b/app/routes/outputs-and-activities.js
@@ -14,6 +14,7 @@ const events = nodes.filter((node) => node.type === 'event');
 
 export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   assetLoader: service(),
+  backgroundImage: service(),
   fastboot: service(),
   headData: service(),
   lightbox: service(),
@@ -132,7 +133,9 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   afterModel() {
     const title = `${get(this, 'intl').t('outputsAndActivities.title')} | ${get(this, 'intl').t('title')}`;
     set(this, 'headData.title', title);
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}outputs-and-activities/`);
+    set(this, 'headData.image', get(this, 'backgroundImage.defaultBackground.fullSizeUrl'));
   },
 
   resetController(controller) {

--- a/app/routes/presidents-message.js
+++ b/app/routes/presidents-message.js
@@ -21,6 +21,7 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   afterModel() {
     const title = `${get(this, 'intl').t('presidentsMessage.title')} | ${get(this, 'intl').t('title')}`;
     set(this, 'headData.title', title);
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}presidents-message/`);
     const backgroundImage = get(this, 'backgroundImage').getSlideBackgroundImage('presidents-message');
     if (backgroundImage && backgroundImage.fullSizeUrl) {

--- a/app/routes/table-of-contents.js
+++ b/app/routes/table-of-contents.js
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   assetLoader: service(),
+  backgroundImage: service(),
   headData: service(),
   intl: service(),
 
@@ -24,6 +25,9 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   },
 
   afterModel() {
+    set(this, 'headData.title', get(this, 'intl').t('title'));
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}table-of-contents/`);
+    set(this, 'headData.image', get(this, 'backgroundImage.defaultBackground.fullSizeUrl'));
   },
 });

--- a/app/routes/thank-you.js
+++ b/app/routes/thank-you.js
@@ -21,6 +21,7 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   afterModel() {
     const title = `${get(this, 'intl').t('thankYou.title')} | ${get(this, 'intl').t('title')}`;
     set(this, 'headData.title', title);
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}thank-you/`);
     const backgroundImage = get(this, 'backgroundImage').getSlideBackgroundImage('thank-you');
     if (backgroundImage && backgroundImage.fullSizeUrl) {

--- a/app/routes/timeline.js
+++ b/app/routes/timeline.js
@@ -15,6 +15,7 @@ const events = nodes.filter((node) => node.type === 'event');
 
 export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   assetLoader: service(),
+  backgroundImage: service(),
   fastboot: service(),
   headData: service(),
   intl: service(),
@@ -123,7 +124,9 @@ export default Route.extend(GoogleAnalyticsMixin, ResetScrollMixin, {
   afterModel() {
     const title = `${get(this, 'intl').t('timeline.title')} | ${get(this, 'intl').t('title')}`;
     set(this, 'headData.title', title);
+    set(this, 'headData.description', get(this, 'intl').t('description'));
     set(this, 'headData.url', `${ENV.host}${ENV.rootURL}timeline/`);
+    set(this, 'headData.image', get(this, 'backgroundImage.defaultBackground.fullSizeUrl'));
   },
 
   resetController(controller) {


### PR DESCRIPTION
Relying on the defaults in `app/routes/application.js` only updates the head data on app load. If navigating to route that doesn't update a head property, that property will simply be from the previous route, not from the default.